### PR TITLE
Update LHModelStateMent.m

### DIFF
--- a/LHDB/LHModelStateMent.m
+++ b/LHDB/LHModelStateMent.m
@@ -111,7 +111,7 @@ NSString* deleteString(Class modelClass,LHPredicate* predicate)
    
     [deleteStr appendString:NSStringFromClass(modelClass)];
     if (predicate.predicateFormat) {
-        [deleteStr appendFormat:@" %@",predicate.predicateFormat];
+        [deleteStr appendFormat:@" WHERE %@",predicate.predicateFormat];
     }
     return deleteStr;
 }


### PR DESCRIPTION
拼接delete语句的时候，少了 " WHERE ",导致拼接的SQL语句错误无法删除数据。详见代码第124行。